### PR TITLE
cast NULL to uintptr_t

### DIFF
--- a/simplelink/kernel/zephyr/dpl/HwiP_zephyr.c
+++ b/simplelink/kernel/zephyr/dpl/HwiP_zephyr.c
@@ -309,6 +309,6 @@ void HwiP_destruct(HwiP_Struct *hwiP)
 	irq_disable(interruptNum - 16);
 
 	obj->cb->cb = NULL;
-	obj->cb->arg = NULL;
+	obj->cb->arg = (uintptr_t)NULL;
 	obj->cb = NULL;
 }

--- a/simplelink/kernel/zephyr/dpl/config.c
+++ b/simplelink/kernel/zephyr/dpl/config.c
@@ -17,7 +17,6 @@
 #include "ti/drivers/rf/RF.h"
 
 #ifdef CONFIG_HAS_CC13X2_CC26X2_SDK
-const PowerCC26X2_Config PowerCC26X2_config;
 const RFCC26XX_HWAttrsV2 RFCC26XX_hwAttrs = {
     .hwiPriority        = INT_PRI_LEVEL7,  // Lowest HWI priority:  INT_PRI_LEVEL7
                                            // Highest HWI priority: INT_PRI_LEVEL1


### PR DESCRIPTION
Get rid of warning

```
/home/cfriedt/workspace/zephyrproject/modules/hal/ti/simplelink/kernel/zephyr/dpl/HwiP_zephyr.c: In function 'HwiP_destruct':
/home/cfriedt/workspace/zephyrproject/modules/hal/ti/simplelink/kernel/zephyr/dpl/HwiP_zephyr.c:312:15: warning: assignment makes integer from pointer without a cast [-Wint-conversion]
  obj->cb->arg = NULL;
               ^
```